### PR TITLE
Fix 'read more' French translation

### DIFF
--- a/themes/blog/i18n/fr.yaml
+++ b/themes/blog/i18n/fr.yaml
@@ -1,5 +1,5 @@
 - id: post_read_more
-  translation: "Lire d'avantage"
+  translation: "Lire la suite ..."
 - id: post_read_post
   translation: "Lire l'article"
 - id: post_wrote_by


### PR DESCRIPTION
"Lire d'avantage" avec l'apostrophe est une petite erreur, mais on l'affiche un peu partout sur le blog. 