### PR TITLE
Correction URL Github de xavierr

### DIFF
--- a/data/authors/xavierr.yaml
+++ b/data/authors/xavierr.yaml
@@ -13,7 +13,7 @@ fr:
 social:
   website:         https://www.elao.com
   twitter:         ~
-  github:          https://github.com/xavier-rdo
+  github:          xavier-rdo
   email:           xavier.roldo@elao.com
   avatar:          authors/xavierr.jpg
   google_plus_id:  ~


### PR DESCRIPTION
A l'heure actuelle, le lien Github pointe vers : `https://github.com/https://github.com/xavier-rdo` >> pas bien ;) Mea culpa.