### PR TITLE
⚓️ Correction des ancres non-cliquables

### DIFF
--- a/themes/2017/assets/sass/base/_typography.scss
+++ b/themes/2017/assets/sass/base/_typography.scss
@@ -16,15 +16,6 @@ h1, h2, h3, h4, h5 {
     a, a:visited { color: $headings-color; }
 }
 
-h1:before, h2:before, h3:before, h4:before, h5:before, h6:before {
-    display: block;
-    content: '';
-    height: 110px;
-    margin-top: -110px;
-    visibility: hidden;
-    content: '';
-}
-
 h1, h2, h3 , h4 {
     margin: 0;
 

--- a/themes/2017/assets/sass/base/_typography.scss
+++ b/themes/2017/assets/sass/base/_typography.scss
@@ -1,4 +1,4 @@
-h1, h2, h3, h4, h5 {
+h1, h2, h3, h4, h5, h6 {
     font-family: $headings-font-family;
     font-weight: $headings-font-weight;
     line-height: $headings-line-height;

--- a/themes/2017/assets/sass/components/_article-content.scss
+++ b/themes/2017/assets/sass/components/_article-content.scss
@@ -14,8 +14,13 @@
     h3,
     h4,
     h5 {
-        position: relative;
-        z-index: -1;
+        &::before {
+            display: block;
+            padding-top: 110px;
+            margin-top: -110px;
+            visibility: hidden;
+            content: '';
+        }
 
         a {
             &, &:visited {

--- a/themes/2017/assets/sass/components/_article-content.scss
+++ b/themes/2017/assets/sass/components/_article-content.scss
@@ -7,13 +7,15 @@
     h3 { margin: 50px 0 15px; }
 
     h4,
-    h5 { margin: 30px 0 15px; }
+    h5,
+    h6 { margin: 30px 0 15px; }
 
     h1,
     h2,
     h3,
     h4,
-    h5 {
+    h5,
+    h6 {
         &::before {
             display: block;
             padding-top: 110px;


### PR DESCRIPTION
http://pr-208.blog.elao.elao.ninja/fr/dev/react-native-font-icon/

1. Les ancres tiennent compte de la hauteur du header
2. Le texte au dessus d'un titre est sélectionnable
3. Les ancres sont cliquable

![screen](https://user-images.githubusercontent.com/1846873/37038793-084204a0-2156-11e8-8d84-ed951d7a2e5b.png)
